### PR TITLE
Add PublishReadyToRun attribute to csproj

### DIFF
--- a/TheoremSlackBot.csproj
+++ b/TheoremSlackBot.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
+    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
ReadyToRun enables ahead-of-time compilation for certain sections of the application binary, and should improve performance somewhat.

See blog post: https://devblogs.microsoft.com/dotnet/announcing-net-core-3-0-preview-6/