### PR TITLE
🖼️ Fix extra slashes in Matrix attachment URIs

### DIFF
--- a/src/Theorem/ChatServices/MatrixChatServiceConnection.cs
+++ b/src/Theorem/ChatServices/MatrixChatServiceConnection.cs
@@ -410,7 +410,7 @@ namespace Theorem.ChatServices
                 // Reconstruct download URL from MXC URI as per
                 // https://spec.matrix.org/v1.3/client-server-api/#get_matrixmediav3downloadservernamemediaidfilename
                 var mxcUrl = new Uri(imageContent.Url);
-                string attachmentUrl = $"{_serverBaseUrl}/_matrix/media/v3/download/" +
+                string attachmentUrl = $"{_serverBaseUrl}_matrix/media/v3/download/" +
                     $"{mxcUrl.Host}{mxcUrl.LocalPath}/file";
 
                 attachments.Add(new AttachmentModel()


### PR DESCRIPTION
An update to the Matrix Synapse server caused extra slashes in attachment URIs to be rejected with a 404.

This change removes the extra slash and allows Theorem to process Matrix attachments properly again.